### PR TITLE
Update Dockerfile to include "which"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:37
 # We goota run as root because npm will install some binaries requried to run the cypress env
 USER root
 # install browser dependencies
-RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs
+RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
 # install yarn and verify node version


### PR DESCRIPTION
Our Jenkins pipeline is hanging for cypress tests as the `which` command is not present in the docker image. See https://ci.int.devshift.net/job/RedHatInsights-insights-rbac-ui-pr-check/451/consoleFull

The dependency on which was added/picked up by: https://github.com/RedHatInsights/frontend-components/pull/2014

```log
10:58:44 [fec] Info:  Starting chrome server...
10:58:44 /bin/sh: line 1: which: command not found
10:58:44 [fec] Error:  Chrome server stopped!
10:58:44 [fec] Error:  Error: No container runtime found
10:58:44     at checkContainerRuntime (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:64:15)
10:58:44     at /home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:198:31
10:58:44     at step (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:33:23)
10:58:44     at Object.next (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:14:53)
10:58:44     at /home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:8:71
10:58:44     at new Promise (<anonymous>)
10:58:44     at __awaiter (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:4:12)
10:58:44     at serveChrome (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:189:12)
10:58:44     at /home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/dev-script.js:150:59
10:58:44     at step (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/dev-script.js:33:23)
10:58:47 making HTTP(S) head request to  url:https://127.0.0.1:1337/webpack-dev-server ...
10:58:47 (node:73) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
10:58:47 (Use `node --trace-warnings ...` to show where the warning was created)
10:58:47   HTTP(S) error for https://127.0.0.1:1337/webpack-dev-server Error: connect ECONNREFUSED 127.0.0.1:1337
```