### PR TITLE
Update Dockerfile to include podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:37
 # We goota run as root because npm will install some binaries requried to run the cypress env
 USER root
 # install browser dependencies
-RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which
+RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which podman
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
 # install yarn and verify node version


### PR DESCRIPTION
Follow up to #5 as the error is now:
```
14:16:50 which: no podman in (/home/tester/workspace/node_modules/.bin:/home/tester/node_modules/.bin:/home/node_modules/.bin:/node_modules/.bin:/usr/lib/node_modules_18/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/home/tester/workspace/node_modules/.bin:/home/tester/node_modules/.bin:/home/node_modules/.bin:/node_modules/.bin:/usr/lib/node_modules_18/npm/node_modules/@npmcli/run-script/lib/node-gyp-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
```