### PR TITLE
Update Dockerfile to fix newuidmap permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ USER root
 # install browser dependencies
 RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which podman
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+# error running podman in rhel - see https://access.redhat.com/solutions/7006710
+RUN setcap cap_setuid+ep /usr/bin/newuidmap
+RUN setcap cap_setgid+ep /usr/bin/newgidmap
 
 # install yarn and verify node version
 RUN npm --version \


### PR DESCRIPTION
Will hopefully resolve the following error:
```
14:35:02 [fec] Info:  Starting chrome server...
14:35:02 (node:91) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
14:35:02 (Use `node --trace-warnings ...` to show where the warning was created)
14:35:02 ERRO[0000] running `/usr/bin/newuidmap 115 0 1000 1 1 524288 65536`: newuidmap: write to uid_map failed: Operation not permitted 
14:35:02 Error: cannot set up namespace using "/usr/bin/newuidmap": should have setuid or have filecaps setuid: exit status 1
14:35:02 [fec] Error:  Chrome server stopped!
14:35:02 [fec] Error:  Error: Command failed: podman pull quay.io/cloudservices/insights-chrome-frontend:71fd911
14:35:02     at checkExecSyncError (node:child_process:890:11)
14:35:02     at execSync (node:child_process:962:15)
14:35:02     at pullImage (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:143:34)
14:35:02     at /home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:209:21
14:35:02     at step (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:33:23)
14:35:02     at Object.next (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:14:53)
14:35:02     at fulfilled (/home/tester/workspace/node_modules/@redhat-cloud-services/frontend-components-config/bin/serve-chrome.js:5:58)
14:35:02     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
14:35:02   status: 125,
14:35:02   signal: null,
14:35:02   output: [ null, null, null ],
14:35:02   pid: 104,
14:35:02   stdout: null,
14:35:02   stderr: null
14:35:02 }
```