### PR TITLE
Revert e2e fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ USER root
 # install browser dependencies
 RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which podman
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-# error running podman in rhel - see https://access.redhat.com/solutions/7006710
-RUN setcap cap_setuid+ep /usr/bin/newuidmap
-RUN setcap cap_setgid+ep /usr/bin/newgidmap
 
 # install yarn and verify node version
 RUN npm --version \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:37
 # We goota run as root because npm will install some binaries requried to run the cypress env
 USER root
 # install browser dependencies
-RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which
+RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
 # install yarn and verify node version

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:37
 # We goota run as root because npm will install some binaries requried to run the cypress env
 USER root
 # install browser dependencies
-RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which podman
+RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel git libnotify-devel GConf2 nss libXScrnSaver alsa-lib nodejs which
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
 # install yarn and verify node version


### PR DESCRIPTION
We still have the following error in the rbac-ui e2e pipeline: 

```
14:55:51 [31mERRO[0m[0000] running `/usr/bin/newuidmap 115 0 1000 1 1 524288 65536`: newuidmap: write to uid_map failed: Operation not permitted 
14:55:51 Error: cannot set up namespace using "/usr/bin/newuidmap": exit status 1
14:55:51 [31m[fec] Error[39m:  Chrome server stopped!
```

Until we agree on a solution as a team - I'm going to revert my changes as they do not resolve the root issue.